### PR TITLE
Removed the usage of `javafx.util.Pair` and replace it with a simple int array.

### DIFF
--- a/client/src/main/java/org/evosuite/testcase/execution/ExecutionTrace.java
+++ b/client/src/main/java/org/evosuite/testcase/execution/ExecutionTrace.java
@@ -22,7 +22,6 @@
  */
 package org.evosuite.testcase.execution;
 
-import javafx.util.Pair;
 import org.evosuite.coverage.dataflow.DefUse;
 import org.evosuite.setup.CallContext;
 import org.evosuite.testcase.execution.ExecutionTraceImpl.BranchEval;
@@ -206,15 +205,15 @@ public interface ExecutionTrace {
 
 	/**
 	 * Retrieve the index-length Pair of the array at a specific layer.
-	 * @return a {@link Pair} object.
+	 * @return an int array of size 2.
 	 */
-	Pair<Integer, Integer> getArrayAccessInfo(int layer);
+	int[] getArrayAccessInfo(int layer);
 
 	/**
 	 * Retrieve the index-length Pair of all arrays accessed at the target line.
 	 * @return a {@link Map} object.
 	 */
-	Map<Integer, Pair<Integer, Integer>> getArrayAccessInfo();
+	Map<Integer, int[]> getArrayAccessInfo();
 
 	/**
 	 * Retrieve detailed line coverage count
@@ -461,9 +460,10 @@ public interface ExecutionTrace {
 	 * Log the query index and the length of an array when one is access.
 	 *
 	 * @param layer an int.
-	 * @param indexAndArrayLength a {@link Pair} object.
+	 * @param indexAndArrayLength an int array of size 2. The first element is the accessed index and the second element
+	 *                            is the length of the array/String.
 	 */
-	public void logArrayAccess(int layer, Pair<Integer, Integer> indexAndArrayLength);
+	public void logArrayAccess(int layer, int[] indexAndArrayLength);
 
 	/**
 	 * Record a mutant execution

--- a/client/src/main/java/org/evosuite/testcase/execution/ExecutionTraceImpl.java
+++ b/client/src/main/java/org/evosuite/testcase/execution/ExecutionTraceImpl.java
@@ -19,7 +19,6 @@
  */
 package org.evosuite.testcase.execution;
 
-import javafx.util.Pair;
 import org.evosuite.Properties;
 import org.evosuite.Properties.Criterion;
 import org.evosuite.TestGenerationContext;
@@ -191,7 +190,7 @@ public class ExecutionTraceImpl implements ExecutionTrace, Cloneable {
 	public Map<String, Map<String, Map<Integer, Integer>>> coverage = Collections
 			.synchronizedMap(new HashMap<String, Map<String, Map<Integer, Integer>>>());
 
-	public Map<Integer, Pair<Integer, Integer>> arrayIndexAndLength = Collections.synchronizedMap(new HashMap<>());
+	public Map<Integer, int[]> arrayIndexAndLength = Collections.synchronizedMap(new HashMap<>());
 
 	public Map<Integer, Integer> coveredFalse = Collections.synchronizedMap(new HashMap<Integer, Integer>());
 
@@ -903,13 +902,13 @@ public class ExecutionTraceImpl implements ExecutionTrace, Cloneable {
 
 	/** {@inheritDoc} */
 	@Override
-	public Map<Integer, Pair<Integer, Integer>> getArrayAccessInfo() {
+	public Map<Integer, int[]> getArrayAccessInfo() {
 		return arrayIndexAndLength;
 	}
 
 	/** {@inheritDoc} */
 	@Override
-	public Pair<Integer, Integer> getArrayAccessInfo(int layer) {
+	public int[] getArrayAccessInfo(int layer) {
 		return getArrayAccessInfo().get(layer);
 	}
 
@@ -1425,7 +1424,7 @@ public class ExecutionTraceImpl implements ExecutionTrace, Cloneable {
 	 * {@inheritDoc}
 	 */
 	@Override
-	public void logArrayAccess(int layer, Pair<Integer, Integer> indexAndArrayLength) {
+	public void logArrayAccess(int layer, int[] indexAndArrayLength) {
 		arrayIndexAndLength.put(layer, indexAndArrayLength);
 	}
 

--- a/client/src/main/java/org/evosuite/testcase/execution/ExecutionTraceProxy.java
+++ b/client/src/main/java/org/evosuite/testcase/execution/ExecutionTraceProxy.java
@@ -22,15 +22,14 @@
  */
 package org.evosuite.testcase.execution;
 
+import org.evosuite.coverage.dataflow.DefUse;
+import org.evosuite.setup.CallContext;
+import org.evosuite.testcase.execution.ExecutionTraceImpl.BranchEval;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import javafx.util.Pair;
-import org.evosuite.coverage.dataflow.DefUse;
-import org.evosuite.setup.CallContext;
-import org.evosuite.testcase.execution.ExecutionTraceImpl.BranchEval;
 
 /**
  * <p>
@@ -191,13 +190,13 @@ public class ExecutionTraceProxy implements ExecutionTrace, Cloneable {
 
 	/** {@inheritDoc} */
 	@Override
-	public Pair<Integer, Integer> getArrayAccessInfo(int layer) {
+	public int[] getArrayAccessInfo(int layer) {
 		return trace.getArrayAccessInfo(layer);
 	}
 
 	/** {@inheritDoc} */
 	@Override
-	public Map<Integer, Pair<Integer, Integer>> getArrayAccessInfo() {
+	public Map<Integer, int[]> getArrayAccessInfo() {
 		return trace.getArrayAccessInfo();
 	}
 
@@ -536,10 +535,10 @@ public class ExecutionTraceProxy implements ExecutionTrace, Cloneable {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @see org.evosuite.testcase.execution.ExecutionTraceImpl#logArrayAccess(int, Pair)
+	 * @see org.evosuite.testcase.execution.ExecutionTraceImpl#logArrayAccess(int, int[])
 	 */
 	@Override
-	public void logArrayAccess(int layer, Pair<Integer, Integer> indexAndArrayLength) {
+	public void logArrayAccess(int layer, int[] indexAndArrayLength) {
 		copyOnWrite();
 		trace.logArrayAccess(layer, indexAndArrayLength);
 	}

--- a/client/src/main/java/org/evosuite/testcase/execution/ExecutionTracer.java
+++ b/client/src/main/java/org/evosuite/testcase/execution/ExecutionTracer.java
@@ -19,9 +19,6 @@
  */
 package org.evosuite.testcase.execution;
 
-import java.util.Map;
-
-import javafx.util.Pair;
 import org.evosuite.coverage.dataflow.DefUsePool;
 import org.evosuite.coverage.dataflow.Definition;
 import org.evosuite.coverage.dataflow.Use;
@@ -30,6 +27,8 @@ import org.evosuite.seeding.ConstantPoolManager;
 import org.objectweb.asm.Opcodes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Map;
 
 
 /**
@@ -433,7 +432,7 @@ public class ExecutionTracer {
 		if (isThreadNeqCurrentThread())
 			return;
 		checkTimeout();
-		tracer.trace.logArrayAccess(layer, new Pair<>(index, length));
+		tracer.trace.logArrayAccess(layer, new int[]{index, length});
 	}
 
 	/**


### PR DESCRIPTION
Because openjdk has problem with `javafx`, see AdoptOpenJDK/openjdk-build#577, I removed all usage of `Pair` so that EvoSuite and Botsing can be built successfully.

plz review @pderakhshanfar 